### PR TITLE
Report cleardeviation failures and warnings, use new config/deviation naming

### DIFF
--- a/mocks/apply/apply.go
+++ b/mocks/apply/apply.go
@@ -42,11 +42,12 @@ func (m *MockApplyClient) EXPECT() *MockApplyClientMockRecorder {
 }
 
 // ClearTargetDeviations mocks base method.
-func (m *MockApplyClient) ClearTargetDeviations(ctx context.Context, resource *v1alpha1.TargetClearDeviation) error {
+func (m *MockApplyClient) ClearTargetDeviations(ctx context.Context, resource *v1alpha1.TargetClearDeviation) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ClearTargetDeviations", ctx, resource)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // ClearTargetDeviations indicates an expected call of ClearTargetDeviations.

--- a/mocks/deviations/deviations.go
+++ b/mocks/deviations/deviations.go
@@ -43,11 +43,12 @@ func (m *MockDeviationClient) EXPECT() *MockDeviationClientMockRecorder {
 }
 
 // ClearTargetDeviations mocks base method.
-func (m *MockDeviationClient) ClearTargetDeviations(ctx context.Context, resource *v1alpha1.TargetClearDeviation) error {
+func (m *MockDeviationClient) ClearTargetDeviations(ctx context.Context, resource *v1alpha1.TargetClearDeviation) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ClearTargetDeviations", ctx, resource)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // ClearTargetDeviations indicates an expected call of ClearTargetDeviations.

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -210,7 +210,9 @@ func (c *ConfigClient) ClearTargetDeviations(ctx context.Context, resource *v1al
 			warnings = append(warnings, fmt.Sprintf("%s: %s", r.Name, w))
 		}
 		if !r.Success {
-			failed = append(failed, fmt.Sprintf("%s: %s", r.Name, strings.Join(r.Errors, "; ")))
+			for _, e := range r.Errors {
+				failed = append(failed, fmt.Sprintf("%s: %s", r.Name, e))
+			}
 		}
 	}
 	if len(failed) > 0 {
@@ -218,7 +220,7 @@ func (c *ConfigClient) ClearTargetDeviations(ctx context.Context, resource *v1al
 		if msg == "" {
 			msg = "clear deviations partially failed"
 		}
-		return warnings, fmt.Errorf("%s: %s", msg, strings.Join(failed, "; "))
+		return warnings, fmt.Errorf("%s:\n%s", msg, strings.Join(failed, "\n"))
 	}
 	return warnings, nil
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	v1Config "github.com/sdcio/config-server/apis/config"
 	"github.com/sdcio/config-server/apis/config/v1alpha1"
@@ -153,7 +155,7 @@ func NewTargetClearDeviation(namespace, targetName string, devs types.Deviations
 	content := make([]v1alpha1.TargetClearDeviationConfig, 0, len(devs))
 	for _, d := range devs {
 		content = append(content, v1alpha1.TargetClearDeviationConfig{
-			Name:  d.Name(),
+			Name:  d.IntentName(),
 			Paths: d.DeviationPaths(),
 		})
 	}
@@ -173,9 +175,11 @@ func NewTargetClearDeviation(namespace, targetName string, devs types.Deviations
 }
 
 // ClearTargetDeviations posts a pre-built TargetClearDeviation to the
-// cleardeviation subresource. Use NewTargetClearDeviation (convert.go) to
-// construct the resource from a types.Deviations value.
-func (c *ConfigClient) ClearTargetDeviations(ctx context.Context, resource *v1alpha1.TargetClearDeviation) error {
+// cleardeviation subresource and returns any non-fatal warnings the
+// server attached to the response. Per-entry failures reported in the
+// 200-OK body are turned into an error so callers don't mistake a
+// partial failure for success.
+func (c *ConfigClient) ClearTargetDeviations(ctx context.Context, resource *v1alpha1.TargetClearDeviation) ([]string, error) {
 	restClient := c.c.ConfigV1alpha1().RESTClient()
 
 	result := restClient.
@@ -187,7 +191,36 @@ func (c *ConfigClient) ClearTargetDeviations(ctx context.Context, resource *v1al
 		Body(resource).
 		Do(ctx)
 
-	return result.Error()
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+
+	rsp := &v1alpha1.TargetClearDeviation{}
+	if err := result.Into(rsp); err != nil {
+		return nil, fmt.Errorf("clear deviations: decode response: %w", err)
+	}
+	if rsp.Status == nil {
+		return nil, nil
+	}
+
+	warnings := append([]string(nil), rsp.Status.Warnings...)
+	var failed []string
+	for _, r := range rsp.Status.Results {
+		for _, w := range r.Warnings {
+			warnings = append(warnings, fmt.Sprintf("%s: %s", r.Name, w))
+		}
+		if !r.Success {
+			failed = append(failed, fmt.Sprintf("%s: %s", r.Name, strings.Join(r.Errors, "; ")))
+		}
+	}
+	if len(failed) > 0 {
+		msg := rsp.Status.Message
+		if msg == "" {
+			msg = "clear deviations partially failed"
+		}
+		return warnings, fmt.Errorf("%s: %s", msg, strings.Join(failed, "; "))
+	}
+	return warnings, nil
 }
 
 func (c *ConfigClient) GetRunningConfig(ctx context.Context, namespace string, name string, format Format) (*v1alpha1.TargetRunningConfig, error) {

--- a/pkg/cmd/apply.go
+++ b/pkg/cmd/apply.go
@@ -77,7 +77,7 @@ func (o *ApplyOptions) Run(_ *cobra.Command) error {
 		return err
 	}
 
-	return apply.Apply(ctx, cl, o.namespace, o.files, o.Out)
+	return apply.Apply(ctx, cl, o.namespace, o.files, o.Out, o.ErrOut)
 }
 
 // NewCmdApply provides a cobra command wrapping ApplyOptions

--- a/pkg/cmd/deviations.go
+++ b/pkg/cmd/deviations.go
@@ -106,7 +106,7 @@ func (o *DeviationOptions) Run(_ *cobra.Command) error {
 	}
 
 	// Run the deviation selection
-	selectedDeviations, err := deviations.Run(ctx, cl, deviations.NewDeviationOptions(o.namespace, opts...))
+	selectedDeviations, err := deviations.Run(ctx, cl, deviations.NewDeviationOptions(o.namespace, opts...), o.ErrOut)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/apply/apply.go
+++ b/pkg/commands/apply/apply.go
@@ -15,12 +15,13 @@ import (
 
 // ApplyClient defines the interface for apply operations.
 type ApplyClient interface {
-	ClearTargetDeviations(ctx context.Context, resource *v1alpha1.TargetClearDeviation) error
+	ClearTargetDeviations(ctx context.Context, resource *v1alpha1.TargetClearDeviation) ([]string, error)
 }
 
 // Apply reads each file (or stdin when path is "-"), decodes all YAML/JSON
 // documents inside, and applies each one via the appropriate client method.
-func Apply(ctx context.Context, cl ApplyClient, namespace string, filePaths []string, out io.Writer) error {
+// Server-side warnings are written to errOut, which may be nil to discard them.
+func Apply(ctx context.Context, cl ApplyClient, namespace string, filePaths []string, out, errOut io.Writer) error {
 	for _, filePath := range filePaths {
 		var data []byte
 		var err error
@@ -33,7 +34,7 @@ func Apply(ctx context.Context, cl ApplyClient, namespace string, filePaths []st
 			return fmt.Errorf("reading %s: %w", filePath, err)
 		}
 
-		if err := applyDocuments(ctx, cl, namespace, data, out); err != nil {
+		if err := applyDocuments(ctx, cl, namespace, data, out, errOut); err != nil {
 			return fmt.Errorf("%s: %w", filePath, err)
 		}
 	}
@@ -41,7 +42,7 @@ func Apply(ctx context.Context, cl ApplyClient, namespace string, filePaths []st
 }
 
 // applyDocuments handles multi-document YAML/JSON files.
-func applyDocuments(ctx context.Context, cl ApplyClient, namespace string, data []byte, out io.Writer) error {
+func applyDocuments(ctx context.Context, cl ApplyClient, namespace string, data []byte, out, errOut io.Writer) error {
 	decoder := k8syaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096)
 	for {
 		var raw json.RawMessage
@@ -57,23 +58,23 @@ func applyDocuments(ctx context.Context, cl ApplyClient, namespace string, data 
 			return fmt.Errorf("reading type metadata: %w", err)
 		}
 
-		if err := applyResource(ctx, cl, namespace, tm.Kind, raw, out); err != nil {
+		if err := applyResource(ctx, cl, namespace, tm.Kind, raw, out, errOut); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func applyResource(ctx context.Context, cl ApplyClient, namespace string, kind string, raw json.RawMessage, out io.Writer) error {
+func applyResource(ctx context.Context, cl ApplyClient, namespace string, kind string, raw json.RawMessage, out, errOut io.Writer) error {
 	switch kind {
 	case v1alpha1.TargetClearDeviationKind:
-		return applyTargetClearDeviation(ctx, cl, namespace, raw, out)
+		return applyTargetClearDeviation(ctx, cl, namespace, raw, out, errOut)
 	default:
 		return fmt.Errorf("unsupported kind %q", kind)
 	}
 }
 
-func applyTargetClearDeviation(ctx context.Context, cl ApplyClient, namespace string, raw json.RawMessage, out io.Writer) error {
+func applyTargetClearDeviation(ctx context.Context, cl ApplyClient, namespace string, raw json.RawMessage, out, errOut io.Writer) error {
 	var resource v1alpha1.TargetClearDeviation
 	if err := json.Unmarshal(raw, &resource); err != nil {
 		return fmt.Errorf("decoding TargetClearDeviation: %w", err)
@@ -84,7 +85,13 @@ func applyTargetClearDeviation(ctx context.Context, cl ApplyClient, namespace st
 		resource.Namespace = namespace
 	}
 
-	if err := cl.ClearTargetDeviations(ctx, &resource); err != nil {
+	warnings, err := cl.ClearTargetDeviations(ctx, &resource)
+	if errOut != nil {
+		for _, w := range warnings {
+			_, _ = fmt.Fprintf(errOut, "Warning: %s\n", w)
+		}
+	}
+	if err != nil {
 		return err
 	}
 

--- a/pkg/commands/apply/apply_test.go
+++ b/pkg/commands/apply/apply_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -45,13 +46,14 @@ spec:
 	var got *v1alpha1.TargetClearDeviation
 	cl.EXPECT().
 		ClearTargetDeviations(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, resource *v1alpha1.TargetClearDeviation) error {
+		DoAndReturn(func(_ context.Context, resource *v1alpha1.TargetClearDeviation) ([]string, error) {
 			got = resource
-			return nil
+			return nil, nil
 		})
 
 	out := &bytes.Buffer{}
-	err := Apply(context.Background(), cl, "from-cli", []string{writeManifest(t, manifest)}, out)
+	errOut := &bytes.Buffer{}
+	err := Apply(context.Background(), cl, "from-cli", []string{writeManifest(t, manifest)}, out, errOut)
 	if err != nil {
 		t.Fatalf("Apply returned error: %v", err)
 	}
@@ -64,6 +66,9 @@ spec:
 	}
 	if s := strings.TrimSpace(out.String()); s != "targetcleardeviation/srl1 applied" {
 		t.Fatalf("unexpected output: %q", s)
+	}
+	if errOut.Len() != 0 {
+		t.Fatalf("unexpected errOut content: %q", errOut.String())
 	}
 }
 
@@ -87,13 +92,13 @@ spec:
 	var got *v1alpha1.TargetClearDeviation
 	cl.EXPECT().
 		ClearTargetDeviations(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, resource *v1alpha1.TargetClearDeviation) error {
+		DoAndReturn(func(_ context.Context, resource *v1alpha1.TargetClearDeviation) ([]string, error) {
 			got = resource
-			return nil
+			return nil, nil
 		})
 
 	out := &bytes.Buffer{}
-	err := Apply(context.Background(), cl, "from-cli", []string{writeManifest(t, manifest)}, out)
+	err := Apply(context.Background(), cl, "from-cli", []string{writeManifest(t, manifest)}, out, io.Discard)
 	if err != nil {
 		t.Fatalf("Apply returned error: %v", err)
 	}
@@ -132,10 +137,10 @@ spec:
 
 	ctrl := gomock.NewController(t)
 	cl := mockapply.NewMockApplyClient(ctrl)
-	cl.EXPECT().ClearTargetDeviations(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+	cl.EXPECT().ClearTargetDeviations(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
 
 	out := &bytes.Buffer{}
-	err := Apply(context.Background(), cl, "default", []string{writeManifest(t, manifest)}, out)
+	err := Apply(context.Background(), cl, "default", []string{writeManifest(t, manifest)}, out, io.Discard)
 	if err != nil {
 		t.Fatalf("Apply returned error: %v", err)
 	}
@@ -154,7 +159,7 @@ metadata:
 	cl := mockapply.NewMockApplyClient(ctrl)
 
 	out := &bytes.Buffer{}
-	err := Apply(context.Background(), cl, "default", []string{writeManifest(t, manifest)}, out)
+	err := Apply(context.Background(), cl, "default", []string{writeManifest(t, manifest)}, out, io.Discard)
 	if err == nil {
 		t.Fatal("expected error for unsupported kind, got nil")
 	}
@@ -180,14 +185,47 @@ spec:
 	ctrl := gomock.NewController(t)
 	cl := mockapply.NewMockApplyClient(ctrl)
 	wantErr := errors.New("backend failed")
-	cl.EXPECT().ClearTargetDeviations(gomock.Any(), gomock.Any()).Return(wantErr)
+	cl.EXPECT().ClearTargetDeviations(gomock.Any(), gomock.Any()).Return(nil, wantErr)
 
 	out := &bytes.Buffer{}
-	err := Apply(context.Background(), cl, "default", []string{writeManifest(t, manifest)}, out)
+	err := Apply(context.Background(), cl, "default", []string{writeManifest(t, manifest)}, out, io.Discard)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
 	if !strings.Contains(err.Error(), wantErr.Error()) {
 		t.Fatalf("expected propagated client error, got %v", err)
+	}
+}
+
+func TestApply_ForwardsServerWarnings(t *testing.T) {
+	t.Parallel()
+
+	manifest := `apiVersion: config.sdcio.dev/v1alpha1
+kind: TargetClearDeviation
+metadata:
+  name: srl1
+spec:
+  config:
+    - name: intent-a
+      paths:
+        - /system/name
+`
+
+	ctrl := gomock.NewController(t)
+	cl := mockapply.NewMockApplyClient(ctrl)
+	cl.EXPECT().
+		ClearTargetDeviations(gomock.Any(), gomock.Any()).
+		Return([]string{"intent-a: path already at desired value"}, nil)
+
+	out := &bytes.Buffer{}
+	errOut := &bytes.Buffer{}
+	if err := Apply(context.Background(), cl, "default", []string{writeManifest(t, manifest)}, out, errOut); err != nil {
+		t.Fatalf("Apply returned error: %v", err)
+	}
+	if !strings.Contains(errOut.String(), "Warning: intent-a: path already at desired value") {
+		t.Fatalf("expected warning on errOut, got %q", errOut.String())
+	}
+	if strings.Contains(out.String(), "Warning") {
+		t.Fatalf("warning leaked to stdout: %q", out.String())
 	}
 }

--- a/pkg/commands/deviations/deviations.go
+++ b/pkg/commands/deviations/deviations.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -29,7 +30,7 @@ var (
 type DeviationClient interface {
 	GetDeviationByName(ctx context.Context, namespace string, deviationName string) (*types.IntentDeviations, error)
 	GetDeviationsByTarget(ctx context.Context, namespace string, targetName string) (types.Deviations, error)
-	ClearTargetDeviations(ctx context.Context, resource *v1alpha1.TargetClearDeviation) error
+	ClearTargetDeviations(ctx context.Context, resource *v1alpha1.TargetClearDeviation) ([]string, error)
 }
 
 // reasonInitial returns the first uppercase character of the reason in brackets
@@ -173,8 +174,10 @@ func selectDeviationsInteractive(deviations types.DeviationSlice, allDeviations 
 	return deviations.FilterByIndexes(idxs), nil
 }
 
-// Run executes the deviation selection and returns the selected deviations
-func Run(ctx context.Context, cl DeviationClient, do *DeviationOptions) (types.Deviations, error) {
+// Run executes the deviation selection and returns the selected deviations.
+// Server-side warnings emitted by a revert are written to warnOut, which
+// may be nil to discard them.
+func Run(ctx context.Context, cl DeviationClient, do *DeviationOptions, warnOut io.Writer) (types.Deviations, error) {
 	var err error
 	devs, err := loadDeviations(ctx, cl, do)
 	if err != nil {
@@ -203,16 +206,23 @@ func Run(ctx context.Context, cl DeviationClient, do *DeviationOptions) (types.D
 	}
 
 	if do.Revert() && selectedDeviations.HasDeviations() {
-		return nil, revert(ctx, cl, do.namespace, selectedDeviations.First().Target(), selectedDeviations)
+		warnings, revertErr := revert(ctx, cl, do.namespace, selectedDeviations.First().Target(), selectedDeviations)
+		if warnOut != nil {
+			for _, w := range warnings {
+				_, _ = fmt.Fprintf(warnOut, "Warning: %s\n", w)
+			}
+		}
+		return nil, revertErr
 	}
 
 	return selectedDeviations, nil
 }
 
-// revert clears the specified paths on a target
-func revert(ctx context.Context, cl DeviationClient, namespace, targetName string, devs types.Deviations) error {
+// revert clears the specified paths on a target and returns any
+// non-fatal warnings the server attached to the response.
+func revert(ctx context.Context, cl DeviationClient, namespace, targetName string, devs types.Deviations) ([]string, error) {
 	if !devs.HasDeviations() {
-		return fmt.Errorf("no deviations provided to clear")
+		return nil, fmt.Errorf("no deviations provided to clear")
 	}
 
 	return cl.ClearTargetDeviations(ctx, client.NewTargetClearDeviation(namespace, targetName, devs))

--- a/pkg/commands/deviations/deviations_test.go
+++ b/pkg/commands/deviations/deviations_test.go
@@ -1,8 +1,11 @@
 package deviations
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
+	"strings"
 	"testing"
 
 	v1alpha1 "github.com/sdcio/config-server/apis/config/v1alpha1"
@@ -32,7 +35,7 @@ func TestRun_ByTargetReturnsSelectedDeviations(t *testing.T) {
 	})
 	defer restore()
 
-	selected, err := Run(context.Background(), cl, NewDeviationOptions("default", WithTarget("target-1")))
+	selected, err := Run(context.Background(), cl, NewDeviationOptions("default", WithTarget("target-1")), io.Discard)
 	if err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
@@ -64,7 +67,7 @@ func TestRun_ByTargetInteractiveReturnsSelectedDeviations(t *testing.T) {
 	})
 	defer restore()
 
-	selected, err := Run(context.Background(), cl, NewDeviationOptions("default", WithTarget("target-1"), WithInteractive(true)))
+	selected, err := Run(context.Background(), cl, NewDeviationOptions("default", WithTarget("target-1"), WithInteractive(true)), io.Discard)
 	if err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
@@ -90,7 +93,7 @@ func TestRun_ByDeviationNameReturnsSelectedDeviations(t *testing.T) {
 	})
 	defer restore()
 
-	selected, err := Run(context.Background(), cl, NewDeviationOptions("default", WithDeviationName("dev-1"), WithInteractive(true)))
+	selected, err := Run(context.Background(), cl, NewDeviationOptions("default", WithDeviationName("dev-1"), WithInteractive(true)), io.Discard)
 	if err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
@@ -111,7 +114,7 @@ func TestRun_NoSelectionReturnsNilInteractive(t *testing.T) {
 	})
 	defer restore()
 
-	selected, err := Run(context.Background(), cl, NewDeviationOptions("default", WithTarget("target-1"), WithInteractive(true)))
+	selected, err := Run(context.Background(), cl, NewDeviationOptions("default", WithTarget("target-1"), WithInteractive(true)), io.Discard)
 	if err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
@@ -182,7 +185,7 @@ func TestRun_SelectPathPrefixOptionWiring(t *testing.T) {
 			})
 			defer restore()
 
-			selected, err := Run(context.Background(), cl, NewDeviationOptions("default", tt.options...))
+			selected, err := Run(context.Background(), cl, NewDeviationOptions("default", tt.options...), io.Discard)
 			if err != nil {
 				t.Fatalf("Run() unexpected error: %v", err)
 			}
@@ -200,7 +203,7 @@ func TestRun_NonInteractiveFilterPath(t *testing.T) {
 	cl := mockdeviations.NewMockDeviationClient(ctrl)
 	cl.EXPECT().GetDeviationsByTarget(gomock.Any(), "default", "target-1").Return(newTestDeviations(), nil)
 
-	selected, err := Run(context.Background(), cl, NewDeviationOptions("default", WithTarget("target-1"), WithFilterPath([]string{"/system/name"})))
+	selected, err := Run(context.Background(), cl, NewDeviationOptions("default", WithTarget("target-1"), WithFilterPath([]string{"/system/name"})), io.Discard)
 	if err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
@@ -219,7 +222,7 @@ func TestRun_FilterPathNoMatchesReturnsError(t *testing.T) {
 	cl := mockdeviations.NewMockDeviationClient(ctrl)
 	cl.EXPECT().GetDeviationsByTarget(gomock.Any(), "default", "target-1").Return(newTestDeviations(), nil)
 
-	selected, err := Run(context.Background(), cl, NewDeviationOptions("default", WithTarget("target-1"), WithFilterPath([]string{"/interfaces"})))
+	selected, err := Run(context.Background(), cl, NewDeviationOptions("default", WithTarget("target-1"), WithFilterPath([]string{"/interfaces"})), io.Discard)
 	if !errors.Is(err, ErrNoDeviationsAfterPathFiltering) {
 		t.Fatalf("Run() error = %v, want errors.Is(..., ErrNoDeviationsAfterPathFiltering)", err)
 	}
@@ -234,17 +237,17 @@ func TestRun_RevertClearsSelectedDeviations(t *testing.T) {
 
 	cl := mockdeviations.NewMockDeviationClient(ctrl)
 	cl.EXPECT().GetDeviationsByTarget(gomock.Any(), "default", "target-1").Return(newTestDeviations(), nil)
-	cl.EXPECT().ClearTargetDeviations(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, resource *v1alpha1.TargetClearDeviation) error {
+	cl.EXPECT().ClearTargetDeviations(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, resource *v1alpha1.TargetClearDeviation) ([]string, error) {
 		if resource.Name != "target-1" {
-			return errors.New("unexpected target name")
+			return nil, errors.New("unexpected target name")
 		}
 		if resource.Namespace != "default" {
-			return errors.New("unexpected namespace")
+			return nil, errors.New("unexpected namespace")
 		}
 		if len(resource.Spec.Config) != 1 || len(resource.Spec.Config[0].Paths) != 1 || resource.Spec.Config[0].Paths[0] != "/system/name" {
-			return errors.New("unexpected resource payload")
+			return nil, errors.New("unexpected resource payload")
 		}
-		return nil
+		return []string{"path /system/name already at desired value"}, nil
 	})
 
 	restore := stubFindDeviationIndexes(func(deviations []*types.Deviation, display func(i int) string, opts ...interface{}) ([]int, error) {
@@ -252,12 +255,16 @@ func TestRun_RevertClearsSelectedDeviations(t *testing.T) {
 	})
 	defer restore()
 
-	selected, err := Run(context.Background(), cl, NewDeviationOptions("default", WithTarget("target-1"), WithInteractive(true), WithRevert(true)))
+	warnOut := &bytes.Buffer{}
+	selected, err := Run(context.Background(), cl, NewDeviationOptions("default", WithTarget("target-1"), WithInteractive(true), WithRevert(true)), warnOut)
 	if err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
 	if selected != nil {
 		t.Fatalf("selected = %v, want nil after revert", selected)
+	}
+	if !strings.Contains(warnOut.String(), "path /system/name already at desired value") {
+		t.Fatalf("warnings not forwarded to writer: %q", warnOut.String())
 	}
 }
 
@@ -266,7 +273,7 @@ func TestRun_NoTargetOrDeviationReturnsError(t *testing.T) {
 	defer ctrl.Finish()
 
 	cl := mockdeviations.NewMockDeviationClient(ctrl)
-	selected, err := Run(context.Background(), cl, NewDeviationOptions("default"))
+	selected, err := Run(context.Background(), cl, NewDeviationOptions("default"), io.Discard)
 	if !errors.Is(err, ErrDeviationOrTargetNotSet) {
 		t.Fatalf("Run() error = %v, want errors.Is(..., ErrDeviationOrTargetNotSet)", err)
 	}
@@ -282,7 +289,7 @@ func TestRun_NoDeviationsFoundReturnsError(t *testing.T) {
 	cl := mockdeviations.NewMockDeviationClient(ctrl)
 	cl.EXPECT().GetDeviationsByTarget(gomock.Any(), "default", "target-1").Return(types.Deviations{}, nil)
 
-	selected, err := Run(context.Background(), cl, NewDeviationOptions("default", WithTarget("target-1")))
+	selected, err := Run(context.Background(), cl, NewDeviationOptions("default", WithTarget("target-1")), io.Discard)
 	if !errors.Is(err, ErrNoDeviationsFound) {
 		t.Fatalf("Run() error = %v, want errors.Is(..., ErrNoDeviationsFound)", err)
 	}
@@ -296,9 +303,12 @@ func TestRevert_WithoutDeviationsReturnsError(t *testing.T) {
 	defer ctrl.Finish()
 
 	cl := mockdeviations.NewMockDeviationClient(ctrl)
-	err := revert(context.Background(), cl, "default", "target-1", types.Deviations{})
+	warnings, err := revert(context.Background(), cl, "default", "target-1", types.Deviations{})
 	if err == nil || err.Error() != "no deviations provided to clear" {
 		t.Fatalf("revert() error = %v, want %q", err, "no deviations provided to clear")
+	}
+	if warnings != nil {
+		t.Fatalf("revert() warnings = %v, want nil", warnings)
 	}
 }
 

--- a/pkg/types/deviations.go
+++ b/pkg/types/deviations.go
@@ -97,6 +97,21 @@ func (d *IntentDeviations) Name() string {
 	return d.name
 }
 
+// IntentName returns the underlying Config or Target resource name that
+// owns this deviation, stripping the "<type>-" prefix that config-server
+// adds when naming Deviation CRs (see apis/config/v1alpha1.DeviationName).
+// Legacy CRs without the prefix return their raw Name unchanged.
+//
+// TODO: replace with v1alpha1.ParseDeviationName once a config-server
+// release exposing it is pinned in go.mod.
+func (d *IntentDeviations) IntentName() string {
+	prefix := string(d.typ) + "-"
+	if rest, ok := strings.CutPrefix(d.name, prefix); ok && rest != "" {
+		return rest
+	}
+	return d.name
+}
+
 func (d *IntentDeviations) Length() int {
 	return len(d.deviations)
 }

--- a/pkg/types/deviations_test.go
+++ b/pkg/types/deviations_test.go
@@ -1,0 +1,28 @@
+package types
+
+import "testing"
+
+func TestIntentDeviations_IntentName(t *testing.T) {
+	cases := map[string]struct {
+		typ  DeviationType
+		name string
+		want string
+	}{
+		"config prefixed": {DeviationTypeConfig, "config-intent1-srl-srl1", "intent1-srl-srl1"},
+		"target prefixed": {DeviationTypeTarget, "target-srl1", "srl1"},
+		// legacy CRs predate the prefix; return the raw name
+		"no known prefix": {DeviationTypeConfig, "intent1-srl-srl1", "intent1-srl-srl1"},
+		// only the leading prefix is stripped, even when the resource itself begins with one
+		"resource name starts with prefix literal": {DeviationTypeConfig, "config-config-name", "config-name"},
+		// don't strip a prefix that doesn't match this IntentDeviations' type
+		"type mismatch returns raw": {DeviationTypeUnknown, "config-intent1", "config-intent1"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			d := NewDeviations("target-x", tc.name, tc.typ, 0)
+			if got := d.IntentName(); got != tc.want {
+				t.Fatalf("IntentName() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- The cleardeviation subresource can return `200 OK` with per-entry errors in the body. The client was silently discarding them. We now decode the response and print failures as a real error so callers actually see them.
- Server warnings — both transaction-level and per-config — are written to stderr in the standard `Warning: <msg>` format, matching how kubectl renders apiserver warnings.
- Cleardeviation requests now carry the underlying Config name. config-server names Deviation CRs as `<type>-<resourceName>`. Now we strip that prefix before posting so config-server's intent lookup resolves on the current patch as well as on newer config-server builds with the dual-name resolver.